### PR TITLE
how to choose specific terms to appear in the world cloud

### DIFF
--- a/_data/theme.yml
+++ b/_data/theme.yml
@@ -23,7 +23,7 @@ browse-buttons: true # true/false, adds previous/next arrows to item pages
 ##########
 # SUBJECTS PAGE
 #
-subjects-fields: subject;creator # set the field to be featured in the cloud (if left blank, none will be generated)
+subjects-fields: title # set the field to be featured in the cloud (if left blank, none will be generated)
 subjects-min: 1 # min size for subject cloud, too many terms = slow load time!
 subjects-stopwords: # boxers;boxing;boxer # set of subjects separated by ;, e.g. boxers;boxing
 

--- a/_includes/js/cloud-js.html
+++ b/_includes/js/cloud-js.html
@@ -7,11 +7,7 @@
 {% endif %}
 
 {% comment %} Capture all cloud terms {% endcomment %} 
-{%- assign raw-terms = "" -%}
-{%- for c in cloud-fields -%}
-{% assign new = items | map: c | compact | join: ";" %}
-{% assign raw-terms = raw-terms | append: ";" | append: new %}
-{%- endfor -%}
+{%- assign raw-terms = "preservation;frontier;society;museum" -%}
 {%- assign raw-terms = raw-terms | downcase | split: ";" -%}
 
 {% comment %} Clean up raw terms {% endcomment %} 


### PR DESCRIPTION
Hi Zaria! We can go over this in person, but here's the change: 

> We wanted to make it so that _you_ set the specific search terms on the subject cloud, rather than identify the terms based on searching. We changed the theme.yml to look at the title field, and then the cloud-js.html to explicitly define the "raw-terms" that should be included in the word cloud (removing lines 11-14). 